### PR TITLE
Add email tool with mailpit support

### DIFF
--- a/apps/api-gateway/package-lock.json
+++ b/apps/api-gateway/package-lock.json
@@ -17,8 +17,8 @@
         "@nestjs/platform-express": "^11.0.1",
         "@prisma/client": "^5.13.0",
         "ai": "^4.3.16",
-        "nodemailer": "^6.9.11",
         "dotenv": "^16.5.0",
+        "nodemailer": "^6.10.1",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
         "zod": "^3.24.3"
@@ -34,6 +34,7 @@
         "@types/express": "^5.0.0",
         "@types/jest": "^29.5.14",
         "@types/node": "^22.15.33",
+        "@types/nodemailer": "^6.4.17",
         "@types/supertest": "^6.0.2",
         "eslint": "^9.18.0",
         "eslint-config-prettier": "^10.0.1",
@@ -3643,6 +3644,15 @@
       "dev": true,
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "6.4.17",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.17.tgz",
+      "integrity": "sha512-I9CCaIp6DTldEg7vyUTZi8+9Vo0hi1/T8gv3C89yk1rSAAzoKQ8H8ki/jBYJSFoH/BisgLP8tkZMlQ91CIquww==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/qs": {
@@ -9269,6 +9279,14 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",

--- a/apps/api-gateway/package-lock.json
+++ b/apps/api-gateway/package-lock.json
@@ -17,6 +17,7 @@
         "@nestjs/platform-express": "^11.0.1",
         "@prisma/client": "^5.13.0",
         "ai": "^4.3.16",
+        "nodemailer": "^6.9.11",
         "dotenv": "^16.5.0",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",

--- a/apps/api-gateway/package.json
+++ b/apps/api-gateway/package.json
@@ -28,6 +28,7 @@
     "@nestjs/platform-express": "^11.0.1",
     "@prisma/client": "^5.13.0",
     "ai": "^4.3.16",
+    "nodemailer": "^6.9.11",
     "dotenv": "^16.5.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",

--- a/apps/api-gateway/package.json
+++ b/apps/api-gateway/package.json
@@ -28,8 +28,8 @@
     "@nestjs/platform-express": "^11.0.1",
     "@prisma/client": "^5.13.0",
     "ai": "^4.3.16",
-    "nodemailer": "^6.9.11",
     "dotenv": "^16.5.0",
+    "nodemailer": "^6.10.1",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "zod": "^3.24.3"
@@ -45,6 +45,7 @@
     "@types/express": "^5.0.0",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.15.33",
+    "@types/nodemailer": "^6.4.17",
     "@types/supertest": "^6.0.2",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",

--- a/apps/api-gateway/src/api/api.controller.ts
+++ b/apps/api-gateway/src/api/api.controller.ts
@@ -1,5 +1,6 @@
 import { Body, Controller, Get, Param, Post, Put } from '@nestjs/common';
 import { generateObject, generateText } from 'ai';
+import { mailTool } from '../tools/mail.tool';
 import { getAIModel } from '../aiProvider';
 import { PrismaService } from '../prisma.service';
 import { mistral } from '@ai-sdk/mistral';
@@ -115,8 +116,13 @@ export class ApiController {
             { role: 'user', content },
           ]
         : [{ role: 'user', content }];
-    const result = await generateText({ model: getAIModel(), messages });
-    return { output: result.text };
+    const result = await generateText({
+      model: getAIModel(),
+      messages,
+      tools: { mail: mailTool },
+      maxSteps: 5
+    })
+    return { output: result.text }
   }
 
   @Post('generative-form')

--- a/apps/api-gateway/src/api/api.controller.ts
+++ b/apps/api-gateway/src/api/api.controller.ts
@@ -120,14 +120,13 @@ export class ApiController {
       model: getAIModel(),
       messages,
       tools: { mail: mailTool },
-      maxSteps: 5
-    })
-    return { output: result.text }
+      maxSteps: 5,
+    });
+    return { output: result.text };
   }
 
   @Post('generative-form')
   async generativeForm(@Body() body: unknown) {
-    console.log('Received body:', body);
     const { input } = body as any as { input?: string };
     const { object } = await generateObject({
       model: getAIModel(),

--- a/apps/api-gateway/src/tools/mail.tool.ts
+++ b/apps/api-gateway/src/tools/mail.tool.ts
@@ -1,0 +1,20 @@
+import { tool } from 'ai'
+import { z } from 'zod'
+import nodemailer from 'nodemailer'
+
+export const mailTool = tool({
+  description: 'send email',
+  parameters: z.object({
+    to: z.string().email().describe('recipient address'),
+    subject: z.string().describe('email subject'),
+    text: z.string().describe('email content')
+  }),
+  async execute({ to, subject, text }) {
+    const transport = nodemailer.createTransport({
+      host: process.env.MAIL_HOST ?? 'mailpit',
+      port: Number(process.env.MAIL_PORT ?? 1025)
+    })
+    await transport.sendMail({ from: 'bot@example.com', to, subject, text })
+    return 'sent'
+  }
+})

--- a/apps/api-gateway/src/tools/mail.tool.ts
+++ b/apps/api-gateway/src/tools/mail.tool.ts
@@ -1,20 +1,20 @@
-import { tool } from 'ai'
-import { z } from 'zod'
-import nodemailer from 'nodemailer'
+import { tool } from 'ai';
+import { z } from 'zod';
+import * as nodemailer from 'nodemailer';
 
 export const mailTool = tool({
   description: 'send email',
   parameters: z.object({
     to: z.string().email().describe('recipient address'),
     subject: z.string().describe('email subject'),
-    text: z.string().describe('email content')
+    text: z.string().describe('email content'),
   }),
   async execute({ to, subject, text }) {
     const transport = nodemailer.createTransport({
-      host: process.env.MAIL_HOST ?? 'mailpit',
-      port: Number(process.env.MAIL_PORT ?? 1025)
-    })
-    await transport.sendMail({ from: 'bot@example.com', to, subject, text })
-    return 'sent'
-  }
-})
+      host: process.env.MAIL_HOST ?? 'localhost',
+      port: Number(process.env.MAIL_PORT ?? 1025),
+    });
+    await transport.sendMail({ from: 'bot@example.com', to, subject, text });
+    return 'sent';
+  },
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,12 @@ services:
     ports:
       - "3000:3000"
 
+  mailpit:
+    image: axllent/mailpit
+    ports:
+      - "8025:8025"
+      - "1025:1025"
+
 volumes:
   nextjs_node_modules_data:
   postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,8 +42,8 @@ services:
     ports:
       - "3000:3000"
 
-  mailpit:
-    image: axllent/mailpit
+  mailhog:
+    image: mailhog/mailhog
     ports:
       - "8025:8025"
       - "1025:1025"
@@ -51,6 +51,5 @@ services:
 volumes:
   nextjs_node_modules_data:
   postgres_data:
-
   api_gateway_node_modules:
   form_gen_node_modules:


### PR DESCRIPTION
## Summary
- add MCP-compatible email tool
- wire the tool into universal chat
- expose mailpit service for SMTP testing

## Testing
- `npm run build` *(fails: nest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d571a6b908332a3025c5ad373d2d9