### PR TITLE
Add MCP tool for CSV email

### DIFF
--- a/apps/api-gateway/src/api/extractor/extractor.controller.ts
+++ b/apps/api-gateway/src/api/extractor/extractor.controller.ts
@@ -2,6 +2,7 @@ import { Body, Controller, Post } from '@nestjs/common';
 import { generateObject, generateText } from 'ai';
 import { getAIModel } from '../../aiProvider';
 import { mailTool } from '../../tools/mail.tool';
+import { mcpTool } from '../../tools/mcp.tool';
 import { PrismaService } from '../../prisma.service';
 import { fieldSchema, formSchema, recordSchema, stepSchema } from '../schemas';
 import { mistral } from '@ai-sdk/mistral';
@@ -114,7 +115,7 @@ export class ExtractorController {
         const result = await generateText({
           model: getAIModel(),
           messages,
-          tools: { mail: mailTool },
+          tools: { mail: mailTool, mcp: mcpTool },
           maxSteps: 5,
         });
         outputs[i] = result.text;

--- a/apps/api-gateway/src/api/universal-chat/universal-chat.controller.ts
+++ b/apps/api-gateway/src/api/universal-chat/universal-chat.controller.ts
@@ -2,6 +2,7 @@ import { Body, Controller, Post } from '@nestjs/common';
 import { generateText } from 'ai';
 import { getAIModel } from '../../aiProvider';
 import { mailTool } from '../../tools/mail.tool';
+import { mcpTool } from '../../tools/mcp.tool';
 import { universalSchema } from '../schemas';
 
 @Controller()
@@ -25,7 +26,7 @@ export class UniversalChatController {
     const result = await generateText({
       model: getAIModel(),
       messages,
-      tools: { mail: mailTool },
+      tools: { mail: mailTool, mcp: mcpTool },
       maxSteps: 5,
     });
     return { output: result.text };

--- a/apps/api-gateway/src/tools/mcp.tool.ts
+++ b/apps/api-gateway/src/tools/mcp.tool.ts
@@ -1,0 +1,33 @@
+import { tool } from 'ai'
+import { z } from 'zod'
+import * as nodemailer from 'nodemailer'
+
+const makeCsv = (records: Record<string, string>[]): string => {
+  const keys = Object.keys(records[0] ?? {})
+  const lines = records.map(r => keys.map(k => `"${String(r[k] ?? '').replace(/"/g, '""')}"`).join(','))
+  return [keys.join(','), ...lines].join('\n')
+}
+
+export const mcpTool = tool({
+  description: 'send email with csv',
+  parameters: z.object({
+    to: z.string().email().describe('recipient address'),
+    subject: z.string().describe('email subject'),
+    text: z.string().describe('email content'),
+    records: z.array(z.record(z.string())).describe('csv data'),
+  }),
+  async execute({ to, subject, text, records }) {
+    const transport = nodemailer.createTransport({
+      host: process.env.MAIL_HOST ?? 'localhost',
+      port: Number(process.env.MAIL_PORT ?? 1025),
+    })
+    await transport.sendMail({
+      from: 'bot@example.com',
+      to,
+      subject,
+      text,
+      attachments: [{ filename: 'data.csv', content: makeCsv(records) }],
+    })
+    return 'sent'
+  },
+})


### PR DESCRIPTION
## Summary
- allow universal chat to email CSV files
- implement MCP tool for email attachments

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e5820b97c833283cd92c3fc0c0e8d